### PR TITLE
BitBake: Allow empty package to enable building SDK with oatpp-staticdev

### DIFF
--- a/classes/oatpp-module.bbclass
+++ b/classes/oatpp-module.bbclass
@@ -31,6 +31,7 @@ DEPENDS = "oatpp"
 SRC_URI = "git://github.com/oatpp/${PN};tag=${PV}"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
+ALLOW_EMPTY_${PN} = "1"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-oatpp/oatpp/oatpp_1.2.5.bb
+++ b/recipes-oatpp/oatpp/oatpp_1.2.5.bb
@@ -31,6 +31,7 @@ PR = "r0"
 SRC_URI = "git://github.com/oatpp/oatpp;tag=1.2.5"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
+ALLOW_EMPTY_${PN} = "1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Adding oatpp-staticdev to TOOLCHAIN_TARGET_TASK of image so that it can
be installed into SDK fails when no package oatpp is available.
This patch will create now create an empty package oatpp.