### PR TITLE
fix SRC_URI: use https for github

### DIFF
--- a/classes/oatpp-module.bbclass
+++ b/classes/oatpp-module.bbclass
@@ -28,7 +28,7 @@ PR = "r0"
 
 DEPENDS = "oatpp"
 
-SRC_URI = "git://github.com/oatpp/${PN};tag=${PV}"
+SRC_URI = "git://github.com/oatpp/${PN};protocol=https;tag=${PV}"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/recipes-oatpp/oatpp/oatpp_1.2.5.bb
+++ b/recipes-oatpp/oatpp/oatpp_1.2.5.bb
@@ -28,7 +28,7 @@ LICENSE = "Apache-2.0"
 PR = "r0" 
 
 
-SRC_URI = "git://github.com/oatpp/oatpp;tag=1.2.5"
+SRC_URI = "git://github.com/oatpp/oatpp;protocol=https;tag=1.2.5"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/recipes-oatpp/oatpp/oatpp_1.3.0.bb
+++ b/recipes-oatpp/oatpp/oatpp_1.3.0.bb
@@ -28,7 +28,7 @@ LICENSE = "Apache-2.0"
 PR = "r0" 
 
 
-SRC_URI = "git://github.com/oatpp/oatpp;tag=1.3.0"
+SRC_URI = "git://github.com/oatpp/oatpp;protocol=https;tag=1.3.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Github does not support the unencrypted Git protocol anymore and recommends to use https instead.
Here is the announcement: https://github.blog/2021-09-01-improving-git-protocol-security-github/